### PR TITLE
[Thermal] Fix for 'show platform fan' command

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -316,7 +316,7 @@ class FanUpdater(object):
              ('drawer_name', drawer_name),
              ('model', str(try_get(fan.get_model))),
              ('serial', str(try_get(fan.get_serial))),
-             ('status', str(fan_fault_status)),
+             ('status', str(fan_fault_status and not(fan_status.under_speed or fan_status.over_speed))),
              ('direction', str(fan_direction)),
              ('speed', str(speed)),
              ('speed_tolerance', str(speed_tolerance)),


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background contaxt?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?

When the fan is under\over speed status should change to 'Not OK' along with red LED color.

#### How did you do it?

Changed the DB 'status' information to consider under\over fan speed.

#### How did you verify/test it?

run 'show platform fan' command.

#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->